### PR TITLE
Branch 3 31

### DIFF
--- a/src/verifai/simulators/xplane/server.py
+++ b/src/verifai/simulators/xplane/server.py
@@ -163,7 +163,8 @@ class XPlaneServer(verifai.server.Server):
             ctes.append(cte); hes.append(heading_err)
             # Run controller for one step, if desired
             if self.controller is not None:
-                self.controller(self.xpcserver, lat, lon, psi, cte, heading_err)
+                controller_arguments = [lat, lon, psi, cte, heading_err]
+                self.controller(self.xpcserver, controller_arguments)
             # Save screenshot for videos
             if self.grab_image is not None:
                 images.append(self.grab_image())
@@ -235,7 +236,7 @@ class XPlaneFalsifier(verifai.falsifier.mtl_falsifier):
                                      fps=self.video_framerate)
 
 
-def run_test(configuration, runway, verbosity=0):
+def run_test(configuration, runway, controller, verbosity=0):
     # Load Scenic scenario
     print('Loading scenario...')
     sampler = verifai.ScenicSampler.fromScenario(configuration['scenario'])
@@ -249,8 +250,9 @@ def run_test(configuration, runway, verbosity=0):
 
     # Set up controller
     framerate = configuration['framerate']
-    controller = simple_controller.control if configuration['controller'] else None
-
+    #controller = simple_controller.control if configuration['controller'] else None
+    controller = controller.control if configuration['controller'] else None
+    
     # Get options for video recording
     video = configuration.get('video')
     if video is None or not video['record']:
@@ -310,6 +312,7 @@ if __name__ == '__main__':
     parser.add_argument('-c', '--config', help='experiment configuration file', default='config.yaml')
     parser.add_argument('-r', '--runway', help='runway configuration file', default='runway.yaml')
     parser.add_argument('-v', '--verbosity', type=int, default=0)
+    parser.add_argument('-u', '--controller', help='controller file', default='controller.py')
     args = parser.parse_args()
 
     # Parse runway configuration
@@ -327,5 +330,6 @@ if __name__ == '__main__':
 
     # Parse experiment configuration
     configuration = load_yaml(args.config)
-
-    run_test(configuration, runway_data, verbosity=args.verbosity)
+    controller = args.controller
+    
+    run_test(configuration, runway_data, controller, verbosity=args.verbosity)

--- a/src/verifai/simulators/xplane/server.py
+++ b/src/verifai/simulators/xplane/server.py
@@ -150,21 +150,21 @@ class XPlaneServer(verifai.server.Server):
             print('Starting run...')
         start = time.time()
         current = start
-        lats, lons, psis, ctes, hes, times, images = [], [], [], [], [], [], []
+        #lats, lons, psis, ctes, hes, times, images = [], [], [], [], [], [], []
+        controller_arguments_cache = {}
+        times, images = [], []
         while current - start < simulation_time:
             times.append(current - start)
             # Get current plane state
             # Use modified getPOSI to get lat/lon in double precision
-            lat, lon, _, _, _, psi, _ = self.xpcserver.getPOSI()
-            lats.append(lat); lons.append(lon); psis.append(psi)
+            #lat, lon, _, _, _, psi, _ = self.xpcserver.getPOSI()
+            #lats.append(lat); lons.append(lon); psis.append(psi)
             # Compute cross-track and heading errors
-            cte = cross_track_distance(start_lat, start_lon, end_lat, end_lon, lat, lon)
-            heading_err = compute_heading_error(self.desired_heading, psi)
-            ctes.append(cte); hes.append(heading_err)
+            #ctes.append(cte); hes.append(heading_err)
             # Run controller for one step, if desired
             if self.controller is not None:
-                controller_arguments = [lat, lon, psi, cte, heading_err]
-                self.controller(self.xpcserver, controller_arguments)
+                #controller_arguments = [lat, lon, psi, cte, heading_err]
+                self.controller(self.xpcserver, controller_arguments_cache)
             # Save screenshot for videos
             if self.grab_image is not None:
                 images.append(self.grab_image())
@@ -182,6 +182,11 @@ class XPlaneServer(verifai.server.Server):
         # Do some simple checks to see if the plane has gotten stuck
         thresh = 0.000001
         end_point_check, mid_point_check = True, True
+        lats = controller_arguments_cache.get('lats', [0])
+        lons = controller_arguments_cache.get('lons', [0])
+        psis = controller_arguments_cache.get('psis', [0])
+        ctes = controller_arguments_cache.get('ctes', [0])
+        hes = controller_arguments_cache.get('hes', [0])
         if abs(lats[0] - lats[-1]) < thresh and abs(lons[0] - lons[-1]) < thresh:
             end_point_check = False
         num_lats = len(lats)

--- a/src/verifai/simulators/xplane/utils/controller.py
+++ b/src/verifai/simulators/xplane/utils/controller.py
@@ -13,15 +13,14 @@ from verifai.simulators.xplane.utils.geometry import (euclidean_dist, quaternion
 
 #def control(server, lat, lon, psi, cte, heading_err):
 def control(server, cache):
+    # Get current plane state
+    # Use modified getPOSI to get lat/lon in double precision
     lat, lon, _, _, _, psi, _ = self.xpcserver.getPOSI()
+    # Compute cross-track and heading errors
+    #ctes.append(cte); hes.append(heading_err)
     cte = cross_track_distance(start_lat, start_lon, end_lat, end_lon, lat, lon)
     heading_err = compute_heading_error(self.desired_heading, psi)
-    var_label_map = {'lats': lat, 'lons': lon, 'psis': psi, 'ctes': cte, 'hes': heading_err}
-    for var in var_label_map:
-        if var not in cache:
-            cache[var] = [var_label_map[var]]
-        else:
-            cache[var].append(var_label_map[var])
+    var_label_map = {'lat': lat, 'lon': lon, 'psi': psi, 'cte': cte, 'he': heading_err}
     rudder = (cte_gain * cte) + (he_gain * heading_err)
     server.sendCTRL([0.0, 0.0, rudder, throttle])
-    return cache
+    return var_label_map

--- a/src/verifai/simulators/xplane/utils/controller.py
+++ b/src/verifai/simulators/xplane/utils/controller.py
@@ -9,6 +9,9 @@ throttle = 0.4  # constant throttle of plane
 cte_gain = 0.1  # gain for cross-track error
 he_gain = 0.05  # gain for heading error
 
-def control(server, lat, lon, psi, cte, heading_err):
+#def control(server, lat, lon, psi, cte, heading_err):
+def control(server, controller_arguments):
+    assert (len(controller_arguments) == 5), "invalid number of arguments"
+    lat, lon, psi, cte, heading_err = controller_arguments
     rudder = (cte_gain * cte) + (he_gain * heading_err)
     server.sendCTRL([0.0, 0.0, rudder, throttle])


### PR DESCRIPTION
- Made it so controller returns only 
var_label_map = {'lat': lat, 'lon': lon, 'psis': psi, 'cte': cte, 'he' : heading_err}
- Append var_label_map to var_maps (new list)
- Generalized predicate function so that it can take in any var_label_map
- Refactored creation of simulation_data dictionary code
- Moved "stuck checker" to its own function so that no parameters are indexed in run_simulation function
@torfah 