### PR TITLE
Fix ScenicSampler with more than 10 objects (again)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "verifai"
-version = "2.1.0"
+version = "2.1.1"
 description = "A toolkit for the formal design and analysis of systems that include artificial intelligence (AI) and machine learning (ML) components."
 authors = [
 	{ name = "Tommaso Dreossi" },

--- a/src/verifai/features/features.py
+++ b/src/verifai/features/features.py
@@ -721,7 +721,21 @@ class ScalarArray(Array):
         return f'ScalarArray({self.domain}, {self.shape})'
 
 class Struct(Domain):
-    """A domain consisting of named sub-domains."""
+    """A domain consisting of named sub-domains.
+
+    The order of the sub-domains is arbitrary: two Structs are considered equal
+    if they have the same named sub-domains, regardless of order. As the order
+    is an implementation detail, accessing the values of sub-domains in points
+    sampled from a Struct should be done by name:
+
+    >>> struct = Struct({'a': Box((0, 1)), 'b': Box((2, 3))})
+    >>> point = struct.uniformPoint()
+    >>> point.b
+    (2.20215292046797,)
+
+    Within a given version of VerifAI, the sub-domain order is consistent, so
+    that the order of columns in error tables is also consistent.
+    """
 
     def __init__(self, domains):
         self.namedDomains = tuple(sorted(domains.items(), key=lambda i: i[0]))

--- a/src/verifai/samplers/scenic_sampler.py
+++ b/src/verifai/samplers/scenic_sampler.py
@@ -194,7 +194,10 @@ def spaceForScenario(scenario, ignoredProperties):
     assert scenario.egoObject is scenario.objects[0]
     doms = (domainForObject(obj, ignoredProperties)
             for obj in scenario.objects)
-    objects = Struct({ f'object{i}': dom for i, dom in enumerate(doms) })
+    objects = Struct({
+        ScenicSampler.nameForObject(i): dom
+        for i, dom in enumerate(doms)
+    })
 
     # create domains for global parameters
     paramDoms = {}
@@ -279,15 +282,30 @@ class ScenicSampler(FeatureSampler):
         return self.pointForScene(self.lastScene)
 
     def pointForScene(self, scene):
-        """Convert a sampled Scenic :obj:`Scene` to a point in our feature space."""
+        """Convert a sampled Scenic :obj:`~scenic.core.scenarios.Scene` to a point in our feature space.
+
+        The `FeatureSpace` used by this sampler consists of 2 features:
+
+            * ``objects``, which is a `Struct` consisting of attributes ``object0``,
+              ``object1``, etc. with the properties of the corresponding objects
+              in the Scenic program. The names of these attributes may change in a
+              future version of VerifAI: use the `nameForObject` function to
+              generate them.
+            * ``params``, which is a `Struct` storing the values of the
+              :term:`global parameters` of the Scenic program (use
+              `paramDictForSample` to extract them).
+        """
         lengths, dom = self.space.domains
         assert lengths is None
         assert scene.egoObject is scene.objects[0]
         objDomain = dom.domainNamed['objects']
         assert len(objDomain.domains) == len(scene.objects)
-        objects = (pointForObject(objDomain.domainNamed[f'object{i}'], obj)
-                   for i, obj in enumerate(scene.objects))
-        objPoint = objDomain.makePoint(*objects)
+        objects = {
+            self.nameForObject(i):
+            pointForObject(objDomain.domainNamed[self.nameForObject(i)], obj)
+            for i, obj in enumerate(scene.objects)
+        }
+        objPoint = objDomain.makePoint(**objects)
 
         paramDomain = dom.domainNamed['params']
         params = {}
@@ -298,8 +316,17 @@ class ScenicSampler(FeatureSampler):
 
         return self.space.makePoint(objects=objPoint, params=paramPoint)
 
+    @staticmethod
+    def nameForObject(i):
+        """Name used in the `FeatureSpace` for the Scenic object with index i.
+
+        That is, if ``scene`` is a :obj:`~scenic.core.scenarios.Scene`, the object
+        ``scene.objects[i]``.
+        """
+        return f'object{i}'
+
     def paramDictForSample(self, sample):
-        """Recover the dict of global parameters from a `ScenicSampler` sample."""
+        """Recover the dict of :term:`global parameters` from a `ScenicSampler` sample."""
         params = sample.params._asdict()
         corrected = {}
         for newName, quotedParam in self.quotedParams.items():

--- a/tests/scenic/test_scenic.py
+++ b/tests/scenic/test_scenic.py
@@ -71,8 +71,14 @@ def test_object_order(new_Object):
     sample = sampler.nextSample()
     objects = sample.objects
     assert len(objects) == 11
-    for i, obj in enumerate(objects):
+    for i in range(len(objects)):
+        name = ScenicSampler.nameForObject(i)
+        obj = getattr(objects, name)
         assert obj.position[:2] == pytest.approx((2*i, 0))
+
+    flat = sampler.space.flatten(sample)
+    unflat = sampler.space.unflatten(flat)
+    assert unflat == sample
 
 ## Active sampling
 


### PR DESCRIPTION
Fixes another problem with the `ScenicSampler` when the scenario has more than 10 objects (the change in 6b602a74f42589558af144113d52b0d14a609729 did not completely solve the problem, and in fact the test I wrote in that commit was wrong).

I also clarified in the documentation that you shouldn't assume anything about the order of sub-domains in a `Struct`. Unfortunately my previous test did make such an assumption, and there may be code out there which does likewise. If you have a `sample` from the `ScenicSampler`, you cannot assume that iterating over `sample.objects` yields the objects in the same order as in the corresponding Scenic `Scene`. Instead, you should access the 5th object in the `Scene` with code like `sample.objects.object5`, or to be future-proof, like `getattr(sample.objects, ScenicSampler.nameForObject(5))`.

I've bumped the patch version number so we can make a bugfix release.