### PR TITLE
Update dependency constraints for Python 3.13 support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
 ]
 
 dependencies = [
-	"numpy ~= 1.21",
+	"numpy >= 1.21",
 	"scipy ~= 1.7",
 	"dotmap ~= 1.3",
 	"metric-temporal-logic >= 0.1.5",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ dependencies = [
 	"joblib ~= 1.2",
 	"dill >= 0.3.1",
 	"future >= 0.18.3",
-	"pandas ~= 1.3",
+	"pandas >= 1.3, <3",
 	"scikit-learn ~= 1.0",
 	"pygame ~= 2.1",
 	"kmodes <= 0.10.2",
@@ -58,7 +58,7 @@ examples = [
 	"gym >= 0.22",
 	"pyglet ~= 1.5",
 	"opencv-python ~= 4.5",
-	"pillow ~= 9.3",
+	"pillow >= 9.3",
 	'pyproj ~= 3.0; python_version < "3.10"',
 	'pyproj ~= 3.3; python_version >= "3.10"',
 ]


### PR DESCRIPTION
This PR updates dependency constraints to ensure compatibility with Python 3.13.

-**Pandas:** Updated to allow version 2.x.
-**Pillow:** Adjusted to support newer releases compatible with Python 3.13.
